### PR TITLE
sdlc(run): update tech-lead-sds input handling (#23)

### DIFF
--- a/agents/tech-lead-sds/SKILL.md
+++ b/agents/tech-lead-sds/SKILL.md
@@ -22,9 +22,15 @@ breakdown from the Architect.
 Use ONLY the paths provided in the task message.
 Do NOT use hardcoded paths like `.sdlc/pipeline/...`.
 
-- Decision artifact — path from task message.
-- Revised plan artifact — path from task message.
+- Decision artifact — path from task message (e.g.,
+  `{{input.architect}}/04-decision.md`). This is your primary input.
 - `documents/design.md` — current SDS.
+
+**Available inputs:** Only artifacts from nodes listed in your pipeline
+`inputs:` are guaranteed to exist. Do NOT attempt to read artifacts from nodes
+not in your input mapping (e.g., reviewer output, tech-lead plan). If the
+task message references a path outside your inputs, skip it and work with
+what you have.
 
 **Path verification:** Before reading input artifacts, verify each path exists.
 If a path from the task message is unreadable, stop and report the error —


### PR DESCRIPTION
## Summary

- **Issue #23** partial implementation: align pipeline roles with GitHub workflow
- Updated `agents/tech-lead-sds/SKILL.md` input artifact handling for pipeline compatibility
- Pipeline run failed at `impl-loop`; only the SKILL.md input fix was produced

## Key Changes

- `agents/tech-lead-sds/SKILL.md`: reference `{{input.architect}}/04-decision.md` as primary input; skip unreachable paths instead of failing; remove stale "revised plan" reference

## Known Limitations

- Full spec (role renaming, agent deletion/creation, pipeline.yaml rewrite, SRS/SDS updates) not implemented — impl-loop failed
- Subsequent run needed for remaining tasks

## Test plan

- [ ] Verify `agents/tech-lead-sds/SKILL.md` input documentation is correct
- [ ] Validate pipeline DAG resolves `tech-lead-sds` inputs correctly
- [ ] Full issue #23 implementation deferred to next run

Closes #23 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)