### PR TITLE
engine: Pipeline summary with agent result details #109

### DIFF
--- a/.sdlc/runs/20260314T175521/plan/decision/04-decision.md
+++ b/.sdlc/runs/20260314T175521/plan/decision/04-decision.md
@@ -1,0 +1,89 @@
+---
+variant: "Variant A: Minimal in-place modification"
+tasks:
+  - desc: "Add extractResultExcerpt() pure function to engine/output.ts"
+    files: ["engine/output.ts", "engine/output_test.ts"]
+  - desc: "Update nodeResult() to use extractResultExcerpt() instead of first-line truncation"
+    files: ["engine/output.ts", "engine/output_test.ts"]
+  - desc: "Add result field to NodeState in engine/types.ts"
+    files: ["engine/types.ts"]
+  - desc: "Add optional result param to markNodeCompleted() in engine/state.ts"
+    files: ["engine/state.ts", "engine/state_test.ts"]
+  - desc: "Add nodeResults to RunSummary and render per-node results in summary()"
+    files: ["engine/output.ts", "engine/output_test.ts"]
+  - desc: "Pass result excerpt to markNodeCompleted() in engine.ts at both call sites and build nodeResults for summary"
+    files: ["engine/engine.ts", "engine/engine_test.ts"]
+---
+
+## Justification
+
+I selected Variant A for three reasons:
+
+1. **Smallest diff, lowest risk.** All changes are localized additions to
+   existing files. No signature refactoring, no new modules. TypeScript compiler
+   catches any type mismatches at `deno task check`.
+
+2. **No premature abstraction.** Variant B's options-object refactor for
+   `markNodeCompleted()` is premature — the function has only 2 optional params
+   (`costUsd`, `result`). The AGENTS.md vision emphasizes domain-agnostic
+   simplicity; adding indirection for a 4-param function contradicts "keep
+   solutions simple." If more fields are needed later, refactoring to an options
+   object is a trivial mechanical change.
+
+3. **Variant C is over-engineering.** A separate `engine/excerpt.ts` module for
+   a single ~10-line pure function used in 2 call sites adds file count without
+   proportional benefit. The function logically belongs in `output.ts` alongside
+   the `nodeResult()` that consumes it.
+
+## Task Descriptions
+
+### Task 1: Add extractResultExcerpt() pure function
+
+Create `extractResultExcerpt(text: string, maxLines?: number, maxChars?: number): string`
+in `engine/output.ts`. Filters empty lines, takes first N non-empty lines
+(default 3), joins with ` | ` separator, truncates to maxChars (default 400).
+Unit tests: empty string, single line, multi-line, blank lines filtered,
+>3 lines truncated, >400 chars truncated.
+
+### Task 2: Update nodeResult() to use extractResultExcerpt()
+
+Replace `split("\n")[0].slice(0, 120)` with `extractResultExcerpt()` call in
+`nodeResult()`. Update existing tests: replace "first line only" assertion with
+multi-line excerpt assertions; update truncation length from 120 to 400 chars.
+
+### Task 3: Add result field to NodeState
+
+Add `result?: string` to `NodeState` interface in `engine/types.ts`. No
+behavioral change — field consumed by subsequent tasks.
+
+### Task 4: Add result param to markNodeCompleted()
+
+Add optional `result?: string` parameter to `markNodeCompleted()` in
+`engine/state.ts`, after existing `costUsd?` param. When provided, persists to
+`NodeState.result`. Tests: round-trip persistence (write + read back from
+state.json), backward compat (existing calls without result still work).
+
+### Task 5: Add nodeResults to RunSummary and render in summary()
+
+Add `nodeResults?: Record<string, string>` to `RunSummary` in
+`engine/output.ts`. Update `summary()`: after "Nodes:" line, if `nodeResults`
+present, render per-node lines: `  <nodeId padded>  <excerpt>`. Tests:
+`summary()` with and without `nodeResults`.
+
+### Task 6: Pass result excerpt at engine call sites and build nodeResults
+
+In `engine/engine.ts`:
+- `executeNode()`: after `markNodeCompleted()`, pass
+  `extractResultExcerpt(result.output.result)` as `result` param.
+- `executeLoopNode()`: pass result excerpt in `onNodeComplete` callback.
+- `printSummary()`: build `nodeResults` from `state.nodes[*].result`, pass to
+  `summary()`.
+Tests: verify `printSummary()` includes node results when present in state.
+
+## Summary
+
+I selected Variant A (minimal in-place modification) for its smallest diff,
+lowest risk, and alignment with the project's domain-agnostic simplicity vision.
+I defined 6 ordered tasks covering both FR-E15 (extractResultExcerpt + nodeResult
+upgrade) and FR-E22 (NodeState.result persistence + summary rendering).
+I created branch `sdlc/issue-109` and opened a draft PR.

--- a/documents/design-engine.md
+++ b/documents/design-engine.md
@@ -91,7 +91,9 @@ graph TD
     `clearPhaseRegistry()` — see §3.2),
     cost aggregation (`updateRunCost()` sums
     `nodes[*].cost_usd` → `total_cost_usd`; called from
-    `markNodeCompleted()` when optional `costUsd` param provided, FR-32)
+    `markNodeCompleted()` when optional `costUsd` param provided, FR-32).
+    `markNodeCompleted()` also accepts optional `result?: string` param
+    (FR-E22) — persists excerpt to `NodeState.result` in `state.json`
   - `agent.ts` — Claude CLI invocation, continuation loop, retry.
     `AgentRunOptions.model` and `InvokeOptions.model`: optional string for
     per-node model selection. `buildClaudeArgs()` emits `--model <value>` when
@@ -171,15 +173,29 @@ graph TD
     `dryRunPlan(levels, labels, postPipelineNodeIds?, runOnMap?)`: renders
     regular DAG levels, then optional "Post-pipeline" section listing `run_on`
     nodes with their conditions (FR-28).
+    `extractResultExcerpt(text: string, maxLines?: number, maxChars?: number): string`
+    (FR-E15): pure function — filters empty lines, takes first N non-empty
+    (default 3), joins with ` | ` separator, truncates to maxChars (default
+    400). Used by `nodeResult()` and `engine.ts` for state persistence.
     `nodeResult(nodeId, output: ClaudeCliOutput)`: one-line agent result
-    summary (FR-30). Guarded by `verbosity !== "quiet"`. Format:
-    `[HH:MM:SS] <nodeId padded>  RESULT: <first line ≤120 chars> | cost=$X.XXXX | duration=Xs | turns=N`.
+    summary (FR-E15). Guarded by `verbosity !== "quiet"`. Format:
+    `[HH:MM:SS] <nodeId padded>  RESULT: <excerpt ≤400 chars> | cost=$X.XXXX | duration=Xs | turns=N`.
+    Uses `extractResultExcerpt()` for multi-line extraction (replaces
+    first-line-only `split("\n")[0].slice(0, 120)` truncation).
+    `RunSummary.nodeResults?: Record<string, string>` (FR-E22): optional
+    per-node result excerpts. `summary()` renders per-node result lines after
+    "Nodes:" when `nodeResults` present: `  <nodeId padded>  <excerpt>`.
     Imports `ClaudeCliOutput` from `types.ts`
   - `engine.ts` — main executor: level iteration, sequential dispatch, verbose
-    input resolution, node result summary display (FR-30),
+    input resolution, node result summary display (FR-E15/E22),
     loop-node log saving via `onNodeComplete` callback,
     phase registry init via `setPhaseRegistry(config)` at engine startup,
     pre-post-pipeline `on_failure_script` execution.
+    `executeNode()`: passes `extractResultExcerpt(result.output.result)` to
+    `markNodeCompleted()` as `result` param (FR-E22).
+    `executeLoopNode()`: passes result excerpt in `onNodeComplete` callback.
+    `printSummary()`: builds `nodeResults` from `state.nodes[*].result`,
+    passes to `summary()` for per-node result rendering.
     Dry-run path (FR-28): applies `collectPostPipelineNodes()` +
     `sortPostPipelineNodes()` + level filtering before calling
     `dryRunPlan()`, passing filtered levels and post-pipeline node IDs with
@@ -302,9 +318,10 @@ graph TD
     a key in `nodes`. Body node ordering derived from `inputs` declarations
     via topo-sort (>1 entry requires at least one `inputs` reference to
     prevent disconnected graph with arbitrary order).
-  - NodeState: `{ ..., cost_usd?: number }` — per-node cost from
-    `ClaudeCliOutput.total_cost_usd`, set at completion via
-    `markNodeCompleted()` optional param (FR-32)
+  - NodeState: `{ ..., cost_usd?: number, result?: string }` — per-node cost
+    from `ClaudeCliOutput.total_cost_usd` and result excerpt (≤400 chars) from
+    `extractResultExcerpt()`, both set at completion via
+    `markNodeCompleted()` optional params (FR-32, FR-E22)
   - RunState: `{ ..., total_cost_usd?: number }` — sum of all
     `nodes[*].cost_usd`, recomputed by `updateRunCost()` on each node
     completion (FR-32)
@@ -360,14 +377,20 @@ graph TD
     `saveAgentLog()` errors caught and warned (non-fatal) — audit I/O must not
     break loop execution. `runDir` resolved via `getRunDir(this.state.run_id)`
     (already in engine scope).
-  - **Node Result Summary** (FR-30): After agent node completion, engine
-    displays one-line result summary via `OutputManager.nodeResult()`.
+  - **Node Result Summary** (FR-E15, FR-E22): After agent node completion,
+    engine displays one-line result summary via `OutputManager.nodeResult()`.
+    `nodeResult()` uses `extractResultExcerpt()` for multi-line extraction
+    (≤3 non-empty lines, ≤400 chars, collapsed via ` | ` separator).
     Two call sites: (1) `executeNode()` — after `markNodeCompleted()`, for
     top-level agent nodes; `executeAgentNode()` returns `AgentResult | null`
-    (was `boolean`), `executeNode()` extracts `.output` field.
+    (was `boolean`), `executeNode()` extracts `.output` field. Passes
+    `extractResultExcerpt(result.output.result)` to `markNodeCompleted()`
+    for state persistence.
     (2) `executeLoopNode()` `onNodeComplete` callback — calls `nodeResult()`
-    when `result.output` exists. Suppressed in quiet mode. Shown in default
-    and verbose modes.
+    when `result.output` exists; passes excerpt to `markNodeCompleted()`.
+    Suppressed in quiet mode. Shown in default and verbose modes.
+    `printSummary()` builds `nodeResults` from persisted `state.nodes[*].result`
+    and passes to `summary()` for per-node result lines in final summary block.
   - **Verbose Edge Cases** (behavioral contracts verified by tests):
     - **Default mode (no `-v`):** All 4 verbose methods produce zero stderr
       output. `OutputManager` constructed with `verbose=false` suppresses all


### PR DESCRIPTION
## Summary

- I upgraded `nodeResult()` from first-line 120-char truncation to multi-line excerpt (≤3 non-empty lines, ≤400 chars) via new `extractResultExcerpt()` pure function (FR-E15)
- I added `NodeState.result` persistence to `state.json` and per-node result rendering in `OutputManager.summary()` (FR-E22)
- I selected Variant A (minimal in-place modification) — smallest diff, lowest risk, no premature abstractions

## Test plan

- [ ] Unit tests for `extractResultExcerpt()` (empty, single-line, multi-line, blank filtering, truncation)
- [ ] Updated `nodeResult()` tests (multi-line excerpt instead of first-line)
- [ ] `markNodeCompleted()` round-trip with `result` param
- [ ] `summary()` rendering with `nodeResults`
- [ ] `deno task check` passes

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)