### PR TITLE
engine: Refactor engine.ts — extract handlers, reduce to <500 LOC (FR-E24)

### DIFF
--- a/.auto-flow/runs/20260314T225700/plan/decision/04-decision.md
+++ b/.auto-flow/runs/20260314T225700/plan/decision/04-decision.md
@@ -1,0 +1,86 @@
+---
+variant: "Variant C: Extract executeAgentNode to agent.ts + executeLoopNode to loop.ts + move utilities"
+tasks:
+  - desc: "Extract executeAgentNode() to engine/agent.ts as free function with explicit params object"
+    files: ["engine/engine.ts", "engine/agent.ts"]
+  - desc: "Extract executeLoopNode() to engine/loop.ts as free function with explicit params object"
+    files: ["engine/engine.ts", "engine/loop.ts"]
+  - desc: "Move printSummary() to OutputManager method in engine/output.ts"
+    files: ["engine/engine.ts", "engine/output.ts"]
+  - desc: "Move copyDir() to engine/state.ts as exported utility"
+    files: ["engine/engine.ts", "engine/state.ts"]
+  - desc: "Update executeNode() in engine.ts to delegate to imported functions; verify all engine_test.ts tests pass"
+    files: ["engine/engine.ts", "engine/engine_test.ts"]
+---
+
+## Justification
+
+I selected Variant C because it reaches the <500 LOC target (~477 lines) without
+creating new modules. Each extraction places code in its natural home:
+
+- `executeAgentNode` (108 lines) → `engine/agent.ts` — agent execution logic
+  belongs with agent infrastructure (`buildClaudeArgs`, `executeClaudeProcess`,
+  `runAgent`). This is the single largest method and the highest-value extraction.
+- `executeLoopNode` (56 lines) → `engine/loop.ts` — loop execution belongs with
+  `runLoop`, `buildLoopBodyOrder`, loop context building.
+- `printSummary` (22 lines) → `OutputManager` in `engine/output.ts` — summary
+  rendering is an output concern, consistent with `nodeResult()`, `summary()`,
+  `dryRunPlan()` already living there.
+- `copyDir` (12 lines) → `engine/state.ts` — filesystem utility alongside
+  `getNodeDir()`, `getRunDir()`.
+
+This aligns with AGENTS.md vision of clean module separation: each engine module
+has a single, well-defined responsibility. No catch-all modules. Existing module
+boundaries are reused rather than new files created.
+
+Variant A was a close second but creates a monolithic `node-exec.ts` that groups
+all four node-type executors together — less cohesive than distributing them to
+their natural domains. Variant B fails the <500 LOC target (~549 lines).
+
+## Task Descriptions
+
+### Task 1: Extract executeAgentNode() to engine/agent.ts
+
+I move `executeAgentNode()` (lines 337-445 of `engine.ts`) to `agent.ts` as a
+free function `executeAgentNode(params: AgentNodeParams)`. The params object
+includes: `nodeId`, `nodeConfig`, `state`, `config`, `output` (OutputManager),
+`options`, `ctx` (template context), `runDir`, `streamLogPath`. The function
+mutates `state` via the reference (session_id, continuations). `engine.ts`
+retains a thin call in `executeNode()` that imports and delegates.
+
+### Task 2: Extract executeLoopNode() to engine/loop.ts
+
+I move `executeLoopNode()` (lines 468-524 of `engine.ts`) to `loop.ts` as a
+free function `executeLoopNode(params: LoopNodeParams)`. Params: `nodeId`,
+`nodeConfig`, `state`, `config`, `output`, `options`, `ctx`, `runDir`. The
+`onNodeComplete` callback (log saving, result display) is passed as a param
+or inlined. `engine.ts` delegates from `executeNode()`.
+
+### Task 3: Move printSummary() to OutputManager
+
+I move `printSummary()` (lines 617-639 of `engine.ts`) to `output.ts` as a
+method `OutputManager.printSummary(state: RunState, config: PipelineConfig)`.
+The method builds `nodeResults` from `state.nodes[*].result` and calls the
+existing `summary()` method. `engine.ts` replaces `this.printSummary()` with
+`this.output.printSummary(this.state, this.config)`.
+
+### Task 4: Move copyDir() to engine/state.ts
+
+I move `copyDir()` (12 lines) to `state.ts` as an exported free function.
+It's a filesystem utility used by `executeMergeNode()` — natural home alongside
+`getNodeDir()`, `ensureRunDirs()`. Import added in `engine.ts`.
+
+### Task 5: Update engine.ts dispatcher + verify tests
+
+I update `executeNode()` to import and call the extracted functions. I verify
+all existing `engine_test.ts` tests pass without modification. If any test
+directly calls moved private methods, I update the import path. LOC target
+verified: ~654 - 177 (moved) + ~15 (imports/delegation) = ~477 lines.
+
+## Summary
+
+I selected Variant C for its natural module placement and <500 LOC achievement
+(~477 lines) without new files. I defined 5 ordered tasks: extract
+`executeAgentNode` → `agent.ts`, extract `executeLoopNode` → `loop.ts`, move
+`printSummary` → `OutputManager`, move `copyDir` → `state.ts`, update
+dispatcher + verify tests. I created branch `sdlc/issue-92` and opened a draft PR.

--- a/documents/design-engine.md
+++ b/documents/design-engine.md
@@ -93,7 +93,10 @@ graph TD
     `nodes[*].cost_usd` → `total_cost_usd`; called from
     `markNodeCompleted()` when optional `costUsd` param provided, FR-32).
     `markNodeCompleted()` also accepts optional `result?: string` param
-    (FR-E22) — persists excerpt to `NodeState.result` in `state.json`
+    (FR-E22) — persists excerpt to `NodeState.result` in `state.json`.
+    **`copyDir(src, dest)` (FR-E24):** exported free function — recursive
+    directory copy utility. Used by `executeMergeNode()` in `engine.ts`.
+    Moved from `engine.ts` as part of module size reduction
   - `agent.ts` — Claude CLI invocation, continuation loop, retry.
     `AgentRunOptions.model` and `InvokeOptions.model`: optional string for
     per-node model selection. `buildClaudeArgs()` emits `--model <value>` when
@@ -149,7 +152,14 @@ graph TD
     `assistant` events — emits only `text` blocks. Default `undefined` =
     all blocks (backward-compatible). Log file writes call without verbosity
     (full output preserved). `onOutput` callback path passes verbosity from
-    `AgentRunOptions` so terminal output is filtered at source
+    `AgentRunOptions` so terminal output is filtered at source.
+    **`executeAgentNode(params: AgentNodeParams)` (FR-E24):** exported free
+    function — extracted from `Engine` class in `engine.ts`. Accepts explicit
+    params object (`nodeId`, `nodeConfig`, `state`, `config`, `output`,
+    `options`, `ctx`, `runDir`, `streamLogPath`). Contains agent invocation,
+    HITL detection/resume, continuation loop, session_id/log persistence.
+    Mutates `state` via reference. `engine.ts` `executeNode()` imports and
+    delegates to this function for `type: "agent"` nodes
   - `loop.ts` — loop node execution with condition extraction, per-iteration
     `AgentResult` accumulation into `LoopResult.bodyResults`.
     `buildLoopBodyOrder()` reads from inline `nodes` sub-object (replaces
@@ -157,7 +167,15 @@ graph TD
     `buildContext()` resolves `inputs` against both sibling body nodes and
     top-level nodes. Accepts `streamLogPath` pattern from engine; computes
     iteration-qualified path `${nodeId}-iter-${i}.jsonl` per body node
-    invocation; forwards to inner `runAgent()` calls
+    invocation; forwards to inner `runAgent()` calls.
+    **`executeLoopNode(params: LoopNodeParams)` (FR-E24):** exported free
+    function — extracted from `Engine` class in `engine.ts`. Accepts explicit
+    params object (`nodeId`, `nodeConfig`, `state`, `config`, `output`,
+    `options`, `ctx`, `runDir`). Contains loop execution orchestration,
+    `onNodeComplete` callback for log saving and result display,
+    `markNodeCompleted()` calls with result excerpts. Mutates `state` via
+    reference. `engine.ts` `executeNode()` imports and delegates for
+    `type: "loop"` nodes
   - `hitl.ts` — HITL detection (`detectHitlRequest`) and poll loop
     (`runHitlLoop`); injectable `scriptRunner`/`claudeRunner` for testing
   - `human.ts` — terminal user input, abort logic
@@ -185,17 +203,25 @@ graph TD
     `RunSummary.nodeResults?: Record<string, string>` (FR-E22): optional
     per-node result excerpts. `summary()` renders per-node result lines after
     "Nodes:" when `nodeResults` present: `  <nodeId padded>  <excerpt>`.
-    Imports `ClaudeCliOutput` from `types.ts`
-  - `engine.ts` — main executor: level iteration, sequential dispatch, verbose
-    input resolution, node result summary display (FR-E15/E22),
-    loop-node log saving via `onNodeComplete` callback,
-    phase registry init via `setPhaseRegistry(config)` at engine startup,
-    pre-post-pipeline `on_failure_script` execution.
+    Imports `ClaudeCliOutput` from `types.ts`.
+    **`printSummary(state: RunState, config: PipelineConfig)` (FR-E24):**
+    method on `OutputManager` — extracted from `Engine` class in `engine.ts`.
+    Builds `nodeResults` from `state.nodes[*].result`, passes to `summary()`
+    for per-node result rendering in final summary block. `engine.ts` calls
+    `this.output.printSummary(this.state, this.config)` instead of private
+    method
+  - `engine.ts` — main executor: level iteration, sequential dispatch,
+    node type delegation to extracted functions (FR-E24), verbose
+    input resolution, phase registry init via `setPhaseRegistry(config)` at
+    engine startup, pre-post-pipeline `on_failure_script` execution.
+    **Module size reduction (FR-E24):** `executeAgentNode()` extracted to
+    `agent.ts`, `executeLoopNode()` extracted to `loop.ts`,
+    `printSummary()` extracted to `OutputManager` in `output.ts`,
+    `copyDir()` extracted to `state.ts`. `executeNode()` dispatches to
+    imported free functions for `agent` and `loop` node types. Target:
+    <500 LOC (from 654 → ~477).
     `executeNode()`: passes `extractResultExcerpt(result.output.result)` to
     `markNodeCompleted()` as `result` param (FR-E22).
-    `executeLoopNode()`: passes result excerpt in `onNodeComplete` callback.
-    `printSummary()`: builds `nodeResults` from `state.nodes[*].result`,
-    passes to `summary()` for per-node result rendering.
     Dry-run path (FR-28): applies `collectPostPipelineNodes()` +
     `sortPostPipelineNodes()` + level filtering before calling
     `dryRunPlan()`, passing filtered levels and post-pipeline node IDs with
@@ -268,14 +294,15 @@ graph TD
     Forwarded to `runAgent()` calls. Enables prompt/validation/continuation
     verbose for loop body nodes. Safety/commit verbose for loop body nodes:
     deferred (loop body bypasses `executeAgentNode()`).
-  - `engine.ts`: `executeAgentNode()` resolves input artifact paths+sizes by
+  - `engine.ts`: `executeNode()` resolves input artifact paths+sizes by
     walking `ctx.input` directories via `Deno.stat()`; calls
-    `this.output.verboseInputs()` before `runAgent()`. Passes `this.output`
-    and `nodeId` to `runAgent()`. Safety check and commit verbose removed
-    (engine no longer performs these — FR-29). `runFailureHook(script?)`:
-    private method (~10 lines), executes `on_failure_script` via
-    `Deno.Command()` on pipeline failure. Swallows errors (failure hook must
-    not crash engine). Replaces hard-wired `rollbackUncommitted()`.
+    `this.output.verboseInputs()` before delegating to `executeAgentNode()`.
+    Passes `this.output` and `nodeId` via params. Safety check and commit
+    verbose removed (engine no longer performs these — FR-29).
+    `runFailureHook(script?)`: private method (~10 lines), executes
+    `on_failure_script` via `Deno.Command()` on pipeline failure. Swallows
+    errors (failure hook must not crash engine). Replaces hard-wired
+    `rollbackUncommitted()`.
   - All existing callers pass no `output` arg — zero behavioral change.
 - **Deps:** `claude` CLI, `deno`, `git`, `jsr:@std/yaml`.
 
@@ -368,16 +395,17 @@ graph TD
   - **Continuation Loop**: invoke agent -> validate -> if fail: resume with
     error context -> repeat (max N). If limit reached: fail node.
   - **Verbose Output Flow** (`-v` mode, agent nodes only): In
-    `executeAgentNode()`: (1) resolve input artifact file paths+sizes from
-    `ctx.input` dirs via `Deno.stat()` → `verboseInputs()`, (2) `runAgent()`
-    (with `output` + `nodeId`) emits `verbosePrompt()` → Claude CLI executes →
-    `verboseValidation()` → on failure: `verboseContinuation()` → retry.
+    `executeNode()`: (1) resolve input artifact file paths+sizes from
+    `ctx.input` dirs via `Deno.stat()` → `verboseInputs()`, (2) delegate to
+    `executeAgentNode()` (in `agent.ts`) which emits `verbosePrompt()` →
+    Claude CLI executes → `verboseValidation()` → on failure:
+    `verboseContinuation()` → retry.
     All verbose methods guarded by `verbosity !== "verbose"` — no-op in
     default/quiet. Output: human-readable stderr lines with section headers.
   - **Loop Node Log Saving** (callback-based, no I/O in `loop.ts`):
     `runLoop()` accumulates `AgentResult` per body-node iteration into
     `LoopResult.bodyResults[]` (pure data, no filesystem ops). In
-    `executeLoopNode()` (`engine.ts`), the `onNodeComplete` callback iterates
+    `executeLoopNode()` (`loop.ts`), the `onNodeComplete` callback iterates
     `bodyResults`, calling `saveAgentLog()` with iteration-qualified nodeId
     (`${id}-iter-${i}`). Guard: only on `result.success && result.output`.
     `saveAgentLog()` errors caught and warned (non-fatal) — audit I/O must not
@@ -395,8 +423,9 @@ graph TD
     (2) `executeLoopNode()` `onNodeComplete` callback — calls `nodeResult()`
     when `result.output` exists; passes excerpt to `markNodeCompleted()`.
     Suppressed in quiet mode. Shown in default and verbose modes.
-    `printSummary()` builds `nodeResults` from persisted `state.nodes[*].result`
-    and passes to `summary()` for per-node result lines in final summary block.
+    `printSummary()` (on `OutputManager`) builds `nodeResults` from persisted
+    `state.nodes[*].result` and passes to `summary()` for per-node result
+    lines in final summary block.
   - **Verbose Edge Cases** (behavioral contracts verified by tests):
     - **Default mode (no `-v`):** All 4 verbose methods produce zero stderr
       output. `OutputManager` constructed with `verbose=false` suppresses all


### PR DESCRIPTION
## Summary

- I selected **Variant C** from the Architect's plan: extract `executeAgentNode` → `agent.ts`, `executeLoopNode` → `loop.ts`, `printSummary` → `OutputManager`, `copyDir` → `state.ts`
- Target: reduce `engine/engine.ts` from 654 → ~477 LOC without creating new modules
- 5 ordered tasks defined for the Developer agent

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)