### PR TITLE
fix(ci): release detector skips engine: and engine+sdlc: commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,33 @@ jobs:
           git config --local user.name "github-actions[bot]"
 
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+          # Detect releasable commits and pick a bump level.
+          #
+          # Conventional-commit prefixes (feat/fix/...) are handled by
+          # standard-version directly. Project-style engine: and
+          # engine+sdlc: prefixes are detected here and forced to a
+          # patch bump because standard-version does not understand
+          # them. sdlc: commits do NOT trigger a release — SDLC workflow
+          # changes are dev tooling, not engine code.
+          RELEASABLE=false
+          BUMP_ARGS=""
+
           if [ -z "$LATEST_TAG" ]; then
             RELEASABLE=true
           else
-            COMMITS=$(git log --oneline --extended-regexp --grep="^(feat|fix|perf|break|refactor|build)" ${LATEST_TAG}..HEAD | wc -l)
-            if [ "$COMMITS" -gt 0 ]; then RELEASABLE=true; else RELEASABLE=false; fi
+            COMMITS_SINCE=$(git log --format='%s' ${LATEST_TAG}..HEAD)
+            if echo "$COMMITS_SINCE" | grep -qE '^feat'; then
+              RELEASABLE=true
+              # standard-version decides minor/major automatically.
+            elif echo "$COMMITS_SINCE" | grep -qE '^(fix|perf|refactor|build|engine)'; then
+              RELEASABLE=true
+              BUMP_ARGS="--release-as patch"
+            fi
           fi
 
           if [ "$RELEASABLE" = "true" ]; then
-            deno task release
+            deno task release $BUMP_ARGS
             NEW_VERSION=$(deno eval "console.log(JSON.parse(Deno.readTextFileSync('deno.json')).version)")
             NEW_TAG="v${NEW_VERSION}"
             git tag -a "$NEW_TAG" -m "Release ${NEW_TAG}"


### PR DESCRIPTION
## Summary

- Release detector only grepped conventional-commit prefixes — the previous PR merged as `engine+sdlc: JSR distribution and self-update check` and was silently skipped, so the JSR package was never published and the pinned actions in build/release jobs were never exercised.
- Extend the regex to also match `engine` (which covers `engine:` and `engine+sdlc:` via prefix). `sdlc:` alone stays excluded — SDLC workflow changes are dev tooling, not engine code shipped to JSR.
- When release is triggered by a patch-level type (fix/perf/refactor/build/engine) and no `feat` is present, pass `--release-as patch` to standard-version, which otherwise would not bump because it does not recognize `engine:`.
- Commit prefix is `fix(ci):` so this PR itself will trigger a release on merge, exercising the full build → GitHub release → `deno publish` pipeline end-to-end.

## Logic table

- `feat: ...` → release, standard-version auto-decides (minor/major)
- `fix:`, `perf:`, `refactor:`, `build:`, `engine:`, `engine+sdlc:` → release, force patch
- `sdlc:`, `docs:`, `chore:`, `chore(release):` → no release

## Test plan

- [x] `deno task check` — green locally
- [x] YAML valid
- [x] Regex matches verified against 8 example commit titles (see PR discussion if needed)
- [ ] CI check job passes on this PR
- [ ] After merge: release job triggers, bumps to 0.1.8, builds 4 binaries, creates GitHub Release, publishes to JSR
- [ ] `deno install -g -A -n flowai-workflow jsr:@korchasa/flowai-workflow` works after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)