### PR TITLE
chore(git): ignore documents/rnd/ research artifacts

### DIFF
--- a/documents/rnd/.gitignore
+++ b/documents/rnd/.gitignore
@@ -1,0 +1,2 @@
+refs/
+claude-code-best-*


### PR DESCRIPTION
## Summary

- Local `documents/rnd/.gitignore` scoped to the research directory — keeps ignore rules next to what they ignore instead of polluting root.
- Patterns: `refs/` (clones of external reference projects) and `claude-code-best-*` (WIP research notes accumulated during sessions).
- `chore:` prefix deliberately chosen: outside the release detector regex, so this does NOT trigger a patch bump or JSR republish for an ignore-file change.

## Verification

- [x] `git check-ignore -v` confirms both patterns match the actual untracked files
- [x] `git status --short` clean after commit
- [ ] CI green on PR (check job only — release jobs correctly skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)