### PR TITLE
docs(readme): link to GitHub Releases instead of listing curl commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,29 +17,7 @@ Pass `--skip-update-check` to suppress the check.
 
 ### Pre-built binary
 
-Download the latest binary for your platform:
-
-```bash
-# macOS (Apple Silicon)
-curl -fsSL https://github.com/korchasa/flowai-workflow/releases/latest/download/flowai-workflow-darwin-arm64 -o flowai-workflow
-chmod +x flowai-workflow
-sudo mv flowai-workflow /usr/local/bin/
-
-# macOS (Intel)
-curl -fsSL https://github.com/korchasa/flowai-workflow/releases/latest/download/flowai-workflow-darwin-x86_64 -o flowai-workflow
-chmod +x flowai-workflow
-sudo mv flowai-workflow /usr/local/bin/
-
-# Linux (x86_64)
-curl -fsSL https://github.com/korchasa/flowai-workflow/releases/latest/download/flowai-workflow-linux-x86_64 -o flowai-workflow
-chmod +x flowai-workflow
-sudo mv flowai-workflow /usr/local/bin/
-
-# Linux (ARM64)
-curl -fsSL https://github.com/korchasa/flowai-workflow/releases/latest/download/flowai-workflow-linux-arm64 -o flowai-workflow
-chmod +x flowai-workflow
-sudo mv flowai-workflow /usr/local/bin/
-```
+Grab the binary for your platform from [GitHub Releases](https://github.com/korchasa/flowai-workflow/releases/latest).
 
 ## Engine Architecture
 


### PR DESCRIPTION
Replaces 4 platform-specific curl+chmod+mv blocks with a single link to the Releases page. Cleaner install section; doc won't go stale when new targets are added.