### PR TITLE
feat(engine)!: per-run worktree co-location (FR-E57)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,8 +90,11 @@ example of engine usage.
     Imported from `kazar-fairy-taler` as a reusable template; retains
     LumaTale-specific `direction` taxonomy as an example)
   Each is self-contained: `workflow.yaml`, `agents/agent-*.md`, `memory/`,
-  `scripts/`, `runs/`, `worktrees/`. Select one by passing it as the
-  mandatory positional argument: `flowai-workflow run <workflow>`.
+  `scripts/`, `runs/<run-id>/{state.json, <node-id>/, worktree/}` (FR-E57:
+  the per-run git worktree lives alongside the run's state and artifacts
+  under one `runs/<run-id>/` umbrella; the legacy top-level `worktrees/`
+  directory is gone). Select one by passing it as the mandatory
+  positional argument: `flowai-workflow run <workflow>`.
   **`deno task run` is hardcoded to `github-inbox`.** To run a different
   variant: `deno run -A --no-check cli.ts run .flowai-workflow/<variant>` —
   or add a per-variant task to `deno.json`.

--- a/README.md
+++ b/README.md
@@ -99,12 +99,14 @@ Every workflow lives in its own self-contained directory:
 
 ```
 .flowai-workflow/<name>/
-    workflow.yaml          # required
-    agents/agent-*.md      # required iff workflow.yaml references agent files
-    memory/                # optional; agent-*.md gitignored (runtime state)
-    scripts/               # optional
-    runs/                  # generated, gitignored
-    worktrees/             # generated, gitignored
+    workflow.yaml                  # required
+    agents/agent-*.md              # required iff workflow.yaml references agent files
+    memory/                        # optional; agent-*.md gitignored (runtime state)
+    scripts/                       # optional
+    runs/<run-id>/                 # generated, gitignored
+        state.json                 # run state (persists across resume)
+        <node-id>/...              # per-node artifact dirs
+        worktree/                  # FR-E57: per-run git worktree
 ```
 
 Multiple workflows in one project: keep them as siblings under
@@ -277,9 +279,13 @@ scripts/                         # Dev tooling (check, compile, dashboard, relea
     workflow.yaml
     agents/agent-*.md            # Agent prompts (per-workflow copy)
     memory/                      # reflection-protocol.md tracked; agent-*.md gitignored
+    runs/<run-id>/               # Per-run umbrella (gitignored). FR-E57: state,
+                                 # node artifacts, and the run's git worktree
+                                 # all live side-by-side here.
+      state.json
+      <node-id>/...
+      worktree/                  # Isolated git worktree (FR-E57)
     scripts/                     # HITL & hook scripts
-    runs/                        # Per-run artifacts and state (gitignored)
-    worktrees/                   # Isolated git worktrees (gitignored)
   github-inbox-opencode/         # Sibling workflow with different runtime
     …
 documents/

--- a/documents/design-engine/03-subsystems.md
+++ b/documents/design-engine/03-subsystems.md
@@ -81,11 +81,12 @@
   - `engine.ts::Engine.run()` — `defaultLockPath(this.workflowDir)`,
     `acquireLock` before any side-effecting work, `releaseLock` in `finally`,
     `onShutdown(() => releaseLock(...))` for SIGINT/SIGTERM cleanup.
-- **Cross-workflow parallelism:** Each workflow folder also owns
-  `<workflowDir>/runs/` (FR-E9) and `<workflowDir>/worktrees/` (FR-E24
-  via state conventions); per-folder locking aligns the concurrency unit
-  with the existing artifact-namespace boundary. No global serialization
-  point remains.
+- **Cross-workflow parallelism:** Each workflow folder owns its
+  `<workflowDir>/runs/<run-id>/` umbrella, which holds both per-run state
+  (FR-E9) and the per-run git worktree (FR-E57: `runs/<run-id>/worktree/`,
+  superseding the pre-FR-E57 repo-global `.flowai-workflow/worktrees/`
+  namespace). Per-folder locking aligns the concurrency unit with the
+  artifact-namespace boundary. No global serialization point remains.
 - **Legacy:** Pre-FR-E54 binaries used a fixed `.flowai-workflow/runs/.lock`
   path. After upgrade, that file is orphaned (never consulted) and may be
   deleted manually. No automatic migration.

--- a/documents/requirements-engine.md
+++ b/documents/requirements-engine.md
@@ -89,3 +89,4 @@ FR-IDs are stable — never renumber them on move.
 - FR-E53 (`--workflow` Sole CLI Selector) → 05-cli-and-observability
 - FR-E54 (Per-Workflow Run Lock)        → 04b-worktree-isolation
 - FR-E55 (`{{flow_file()}}` Template)   → 04-runtime-and-hooks
+- FR-E57 (Per-Run Worktree Co-Location) → 04b-worktree-isolation

--- a/documents/requirements-engine/04b-worktree-isolation.md
+++ b/documents/requirements-engine/04b-worktree-isolation.md
@@ -220,9 +220,11 @@ template path contract (FR-E52), and the per-workflow run lock (FR-E54).
     (FR-E25 invariants preserved).
   - `EngineOptions.lock_path` override (test-only) still wins when set —
     no auto-derivation when explicit.
-  - `worktrees/` directory is **already** per-workflow (`<workflowDir>/worktrees/`
-    via `getRunDir`/state conventions); no further worktree-layout change
-    required for cross-workflow parallelism.
+  - **Worktree namespace was NOT yet per-workflow at FR-E54 time.** Code
+    used a repo-global `WORKTREE_BASE = ".flowai-workflow/worktrees"`,
+    so two distinct workflow folders running concurrently would have
+    collided in that one path. FR-E57 closes the gap by relocating
+    worktrees to `<workflowDir>/runs/<run-id>/worktree/` — see §3.55.
 - **Acceptance criteria:**
   - [x] `defaultLockPath(workflowDir)` returns `<workflowDir>/runs/.lock`.
     Evidence: `lock.ts:22-24`.
@@ -240,3 +242,91 @@ template path contract (FR-E52), and the per-workflow run lock (FR-E54).
   - [x] `EngineOptions.lock_path` JSDoc reflects the new default
     (`<workflowDir>/runs/.lock`). Evidence: `types.ts:405-407`.
   - [x] `deno task check` passes.
+
+### 3.55 FR-E57: Per-Run Worktree Co-Location
+
+- **Description:** Each run's git worktree is materialized at
+  `<workflowDir>/runs/<run-id>/worktree/`, sibling to its `state.json` and
+  per-node artifact directories. Replaces the pre-FR-E57 repo-global
+  `.flowai-workflow/worktrees/<run-id>/` location. `<workflowDir>` is the
+  folder containing `workflow.yaml` (FR-S47, FR-E53). The engine derives it
+  once via `deriveWorkflowDir(options.config_path)` and threads it into
+  `getWorktreePath(runId, workflowDir)`, `createWorktree(runId, workflowDir,
+  ref?)`, and `worktreeExists(runId, workflowDir)`.
+- **Motivation:**
+  - **Self-contained run directory:** A single path
+    `<workflowDir>/runs/<run-id>/` now contains everything tied to a run
+    (state, artifacts, live worktree). Inspection, archival, and bulk
+    cleanup operate on one tree.
+  - **Cross-workflow worktree namespace:** FR-E54 already split runs and
+    locks per workflow folder, but `worktree.ts` kept a repo-global
+    `WORKTREE_BASE = ".flowai-workflow/worktrees"`. Two distinct workflow
+    folders running concurrently would have collided in that single
+    namespace. FR-E57 closes the gap so cross-workflow parallel runs are
+    fully isolated.
+  - **Doc/code alignment:** `documents/requirements-engine/04b-...md:223`
+    (FR-E54 constraints) already asserted the worktree directory was
+    "already per-workflow" — that was aspirational. FR-E57 makes it true.
+- **Constraints:**
+  - `worktree_disabled: true` mode (workDir = "."): all `workflowDir`-aware
+    calls become no-ops. Existing semantics preserved.
+  - **Fail-fast when `workflowDir === "."` and worktree mode is active.**
+    `deriveWorkflowDir` returns `"."` when `workflow.yaml` is passed
+    without a directory prefix (legacy back-compat for callers predating
+    FR-S47/FR-E53). Under FR-E57 that would put the worktree at
+    `./runs/<run-id>/worktree`, not covered by `.gitignore`. The engine
+    refuses this combination at run start with a message naming
+    FR-S47/FR-E53. Users must either pass a `workflow.yaml` inside a
+    workflow folder or set `worktree_disabled: true`.
+  - **One-release legacy fallback for resume.** `worktreeExists(runId,
+    workflowDir)` first probes the new path, then falls back to
+    `.flowai-workflow/worktrees/<run-id>` (with a one-line warning) so an
+    in-flight run survives an upgrade across the boundary. The fallback
+    is scheduled for removal in a follow-up FR; new worktrees are never
+    created at the legacy path.
+  - **Cleanup hygiene.** `removeWorktree(path)` calls `git worktree prune`
+    after a successful `git worktree remove --force` (errors swallowed —
+    idempotent). Prevents stale gitlinks from blocking later removal of
+    the parent `runs/<run-id>/` directory.
+  - **`git worktree add` writes an absolute gitdir path into the
+    worktree's `.git` file.** Existing worktrees are never relocated by
+    this change — only new worktrees adopt the new layout.
+  - Engine remains domain-agnostic. Path computation is parametrized by
+    `workflowDir`; no SDLC- or git-workflow-specific knowledge added.
+- **Acceptance criteria:**
+  - [x] `getWorktreePath(runId, workflowDir)` returns
+    `<workflowDir>/runs/<run-id>/worktree`. Old single-arg signature
+    removed. Evidence: `worktree.ts:31-33`. Test:
+    `worktree_test.ts::getWorktreePath — returns
+    <workflowDir>/runs/<runId>/worktree (FR-E57)`.
+  - [x] `createWorktree(runId, workflowDir, ref?)` materializes the
+    worktree at the path returned by `getWorktreePath` and ensures the
+    parent `<workflowDir>/runs/<run-id>/` directory exists before
+    invoking `git worktree add`. Evidence: `worktree.ts:46-66`. Test:
+    `worktree_test.ts::worktree lifecycle — create, exists, remove
+    (FR-E57 layout)`.
+  - [x] `worktreeExists(runId, workflowDir)` prefers the new layout and
+    falls back to the legacy `.flowai-workflow/worktrees/<run-id>` path
+    only when probing for resume. Evidence: `worktree.ts:111-138`. Tests:
+    `worktree_test.ts::worktreeExists — prefers new layout over legacy
+    (FR-E57)` and `worktreeExists — falls back to legacy path when only
+    legacy exists (FR-E57)`.
+  - [x] `Engine.run()` invokes `createWorktree(runId, this.workflowDir)`
+    and uses `resolveExistingWorktreePath(runId, this.workflowDir)` for
+    resume (legacy-aware probe). Evidence: `engine.ts:144-181`.
+  - [x] `Engine.run()` rejects a worktree-mode run when
+    `workflowDir === "."` with an error referencing FR-S47/FR-E53.
+    Evidence: `engine.ts:144-153`. Test: `engine_test.ts::Engine.run() —
+    rejects worktree mode when workflow.yaml is at repo root (FR-E57)`.
+  - [x] `removeWorktree(path)` calls `git worktree prune` after the
+    primary remove. Evidence: `worktree.ts:91-97`. Test:
+    `worktree_test.ts::removeWorktree — prunes stale gitlink after
+    manual dir removal (FR-E57)`.
+  - [x] Two distinct `workflowDir` values hold worktrees at disjoint
+    filesystem paths; concurrent runs across workflow folders do not
+    collide. Evidence: `worktree.ts:31-33`. Tests:
+    `worktree_test.ts::createWorktree — distinct workflow dirs hold
+    independent worktrees (FR-E57)` and
+    `e2e_worktree_isolation_test.ts::e2e — distinct workflow dirs hold
+    independent worktrees (FR-E57)`.
+  - [x] `deno task check` passes (798 tests, 0 failures).

--- a/documents/requirements-sdlc/04-artifacts-and-memory.md
+++ b/documents/requirements-sdlc/04-artifacts-and-memory.md
@@ -224,8 +224,9 @@
   - `workflow.yaml` — engine config; `name:` matches `<name>`.
   - `agents/agent-*.md` — REQUIRED iff `workflow.yaml` references any
     `{{file("…/agents/agent-*.md")}}` prompt. Optional otherwise.
-- **Optional entries:** `memory/`, `scripts/`, `runs/`, `worktrees/`,
-  `tasks/`, `.gitignore`, `.template.json`.
+- **Optional entries:** `memory/`, `scripts/`, `runs/`, `tasks/`,
+  `.gitignore`, `.template.json`. (FR-E57: per-run worktrees live under
+  `runs/<run-id>/worktree/` — there is no top-level `worktrees/` folder.)
 - **Cross-workflow drift:** Agent prompt copies between workflow
   folders are intentional duplicates. Edits to a shared agent must be
   applied to every copy or a deliberate divergence must be recorded

--- a/e2e_worktree_isolation_test.ts
+++ b/e2e_worktree_isolation_test.ts
@@ -63,18 +63,22 @@ async function setupRepoPair(): Promise<{ origin: string; clone: string }> {
   await git(clone, "config", "user.name", "Test");
   await git(clone, "checkout", "-b", "main");
   await Deno.writeTextFile(`${clone}/README.md`, "init\n");
-  // Ignore the worktrees dir so its presence doesn't pollute `git status`
-  // on main — same convention as the real repo's root `.gitignore`.
+  // Ignore the runs dir so worktrees co-located under
+  // <workflowDir>/runs/<id>/worktree/ (FR-E57) don't pollute `git status`
+  // on main — mirrors the real repo's root `.gitignore`.
   await Deno.writeTextFile(
     `${clone}/.gitignore`,
-    ".flowai-workflow/worktrees/\n",
+    ".flowai-workflow/*/runs/\n",
   );
   await git(clone, "add", "README.md", ".gitignore");
   await git(clone, "commit", "-m", "init");
   await git(clone, "push", "-u", "origin", "main");
-  await Deno.mkdir(`${clone}/.flowai-workflow/worktrees`, { recursive: true });
   return { origin, clone };
 }
+
+/** Workflow folder used by the e2e suite. Mirrors the FR-E57 contract:
+ * `<workflowDir>/runs/<run-id>/worktree/`. */
+const WF_DIR = ".flowai-workflow/e2e";
 
 /**
  * Run `body` with `Deno.cwd()` switched to `cwd`. Restores the original cwd
@@ -96,7 +100,7 @@ Deno.test("e2e — happy path leaves main clean (FR-E50, FR-E51)", async () => {
   try {
     await withCwd(clone, async () => {
       const runId = "e2e-happy-001";
-      const workDir = await createWorktree(runId);
+      const workDir = await createWorktree(runId, WF_DIR);
 
       // Simulate an agent that writes only inside its assigned workDir —
       // exactly the contract the guardrail must accept.
@@ -144,7 +148,7 @@ Deno.test("e2e — abs-path leak triggers guardrail (FR-E50)", async () => {
   try {
     await withCwd(clone, async () => {
       const runId = "e2e-leak-001";
-      const workDir = await createWorktree(runId);
+      const workDir = await createWorktree(runId, WF_DIR);
       const messages: string[] = [];
 
       // Simulate an agent that misroutes a write to the main repo via
@@ -196,7 +200,7 @@ Deno.test("e2e — detached HEAD pins to rescue branch (FR-E51)", async () => {
   try {
     await withCwd(clone, async () => {
       const runId = "e2e-detached-001";
-      const workDir = await createWorktree(runId);
+      const workDir = await createWorktree(runId, WF_DIR);
       const absWorkDir = `${clone}/${workDir}`;
 
       // Simulate an in-worktree commit that lives only on detached HEAD.
@@ -235,6 +239,47 @@ Deno.test("e2e — detached HEAD pins to rescue branch (FR-E51)", async () => {
       // And the commit itself is reachable via the branch.
       const reach = await git(clone, "cat-file", "-t", branchSha);
       assertEquals(reach, "commit");
+    });
+  } finally {
+    await Deno.remove(origin, { recursive: true });
+    await Deno.remove(clone, { recursive: true });
+  }
+});
+
+Deno.test("e2e — distinct workflow dirs hold independent worktrees (FR-E57)", async () => {
+  const { origin, clone } = await setupRepoPair();
+  try {
+    await withCwd(clone, async () => {
+      const runId = "shared-run-id";
+      const wfA = ".flowai-workflow/wf-a";
+      const wfB = ".flowai-workflow/wf-b";
+
+      const pathA = await createWorktree(runId, wfA);
+      const pathB = await createWorktree(runId, wfB);
+
+      // Paths are workflowDir-scoped — same runId, disjoint locations.
+      assertEquals(pathA, `${wfA}/runs/${runId}/worktree`);
+      assertEquals(pathB, `${wfB}/runs/${runId}/worktree`);
+      assertEquals(pathA === pathB, false);
+
+      // Both physically materialize side by side under the same clone.
+      assertEquals((await Deno.stat(`${clone}/${pathA}`)).isDirectory, true);
+      assertEquals((await Deno.stat(`${clone}/${pathB}`)).isDirectory, true);
+
+      // Removing wf-a's worktree leaves wf-b intact.
+      await removeWorktree(pathA);
+      const aGone = await Deno.stat(`${clone}/${pathA}`).then(
+        () => false,
+        () => true,
+      );
+      assertEquals(aGone, true, "wf-a worktree must be gone after removal");
+      assertEquals(
+        (await Deno.stat(`${clone}/${pathB}`)).isDirectory,
+        true,
+        "wf-b worktree must survive removal of wf-a",
+      );
+
+      await removeWorktree(pathB);
     });
   } finally {
     await Deno.remove(origin, { recursive: true });

--- a/engine.ts
+++ b/engine.ts
@@ -64,10 +64,9 @@ import {
 import {
   copyToOriginalRepo,
   createWorktree,
-  getWorktreePath,
   pinDetachedHead,
   removeWorktree,
-  worktreeExists,
+  resolveExistingWorktreePath,
 } from "./worktree.ts";
 
 /** Main workflow engine. Orchestrates node execution across DAG levels. */
@@ -137,10 +136,34 @@ export class Engine {
     const runLabel = this.options.args.prompt?.slice(0, 20) ?? undefined;
     const runId = this.options.run_id ?? generateRunId(runLabel);
 
+    // FR-E57: a workflow.yaml passed without a directory prefix collapses
+    // workflowDir to "." and would put the worktree at repo-root
+    // ./runs/<id>/worktree, not covered by .gitignore. The mandatory
+    // positional <workflow> argument introduced by FR-S47/FR-E53 makes
+    // this combination obsolete in normal use; refuse it explicitly.
+    if (!worktreeDisabled && this.workflowDir === ".") {
+      throw new Error(
+        "worktree mode requires workflow.yaml to live inside a workflow folder " +
+          "(FR-S47/FR-E53); pass `<workflow>` positional argument or set " +
+          "worktree_disabled: true",
+      );
+    }
+
     if (this.options.resume && this.options.run_id) {
-      // Resume: reuse existing worktree if it exists
-      if (!worktreeDisabled && worktreeExists(this.options.run_id)) {
-        this.workDir = getWorktreePath(this.options.run_id);
+      // Resume: reuse existing worktree if it exists. Honours the FR-E57
+      // legacy-resume fallback so an in-flight run on the old layout
+      // survives a binary upgrade.
+      const existing = !worktreeDisabled
+        ? resolveExistingWorktreePath(this.options.run_id, this.workflowDir)
+        : undefined;
+      if (existing) {
+        this.workDir = existing.path;
+        if (existing.legacy) {
+          this.output.warn(
+            `legacy worktree layout at ${existing.path}; new runs use ` +
+              `${this.workflowDir}/runs/<id>/worktree (FR-E57)`,
+          );
+        }
         this.output.status("engine", `RESUME worktree: ${this.workDir}`);
       } else {
         this.workDir = ".";
@@ -148,7 +171,7 @@ export class Engine {
     } else if (!worktreeDisabled) {
       // New run: create worktree
       this.output.status("engine", "Creating worktree...");
-      this.workDir = await createWorktree(runId);
+      this.workDir = await createWorktree(runId, this.workflowDir);
       this.output.status("engine", `Worktree: ${this.workDir}`);
     } else {
       this.workDir = ".";

--- a/engine_test.ts
+++ b/engine_test.ts
@@ -103,6 +103,86 @@ Deno.test("Engine — verbose mode accepted", () => {
   assertEquals(typeof engine.run, "function");
 });
 
+// FR-E57: a workflow.yaml passed without a directory prefix would collapse
+// `workflowDir` to "." and place the worktree at repo-root `./runs/<id>/worktree`,
+// which `.gitignore` does not cover. Engine must refuse this combination
+// before the worktree is created. Setting `worktree_disabled: true` keeps the
+// legacy direct-cwd mode working.
+Deno.test("Engine.run() — rejects worktree mode when workflow.yaml is at repo root (FR-E57)", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  const origCwd = Deno.cwd();
+  try {
+    // Minimal workflow.yaml at the repo root — no directory prefix in the
+    // path passed to the engine, so deriveWorkflowDir returns ".".
+    await Deno.writeTextFile(`${tmpDir}/workflow.yaml`, "name: rootless\n");
+    Deno.chdir(tmpDir);
+
+    const engine = new Engine(makeOptions({ config_path: "workflow.yaml" }));
+
+    let thrown: Error | undefined;
+    try {
+      await engine.run();
+    } catch (e) {
+      thrown = e as Error;
+    }
+    assertEquals(thrown !== undefined, true);
+    assertEquals(
+      thrown!.message.includes("workflow folder"),
+      true,
+      `error should mention "workflow folder", got: ${thrown!.message}`,
+    );
+    assertEquals(
+      thrown!.message.includes("FR-S47") || thrown!.message.includes("FR-E53"),
+      true,
+      `error should reference FR-S47/FR-E53, got: ${thrown!.message}`,
+    );
+  } finally {
+    Deno.chdir(origCwd);
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("Engine.run() — accepts root workflow.yaml when worktree_disabled (FR-E57)", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  const origCwd = Deno.cwd();
+  try {
+    // worktree_disabled: true bypasses the FR-E57 guard. The flag lives
+    // under `defaults:` per the workflow schema (see extractWorktreeDisabled).
+    await Deno.writeTextFile(
+      `${tmpDir}/workflow.yaml`,
+      "name: rootless\ndefaults:\n  worktree_disabled: true\n",
+    );
+    Deno.chdir(tmpDir);
+
+    const engine = new Engine(makeOptions({
+      config_path: "workflow.yaml",
+      // Lock path forced to a temp file so we don't fight the global lock dir.
+      lock_path: `${tmpDir}/test.lock`,
+    }));
+
+    // run() will still fail on later phases (no real config nodes etc.), but
+    // it must NOT fail with the FR-E57 guard message — that's the point.
+    let thrown: Error | undefined;
+    try {
+      await engine.run();
+    } catch (e) {
+      thrown = e as Error;
+    }
+    if (thrown !== undefined) {
+      assertEquals(
+        thrown.message.includes("workflow folder") &&
+          (thrown.message.includes("FR-S47") ||
+            thrown.message.includes("FR-E53")),
+        false,
+        `should not be FR-E57 guard error, got: ${thrown.message}`,
+      );
+    }
+  } finally {
+    Deno.chdir(origCwd);
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
 // --- resolveInputArtifacts tests ---
 
 Deno.test("resolveInputArtifacts — returns files with sizes from real directory", async () => {

--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -130,7 +130,9 @@ async function listWorkflowFolders(root: string): Promise<string[]> {
 /** FR-S47/DoD-1: enforce that a workflow folder has the required shape.
  * `workflow.yaml` is required. `agents/` is required IFF the workflow uses
  * agent prompt files (i.e. `workflow.yaml` references `agents/agent-*.md`).
- * `memory/`, `scripts/`, `runs/`, `worktrees/` are always optional.
+ * `memory/`, `scripts/`, `runs/` are always optional. (FR-E57: per-run git
+ * worktrees live under `runs/<run-id>/worktree/`, not at a top-level
+ * `worktrees/` folder; the latter never appears in fresh layouts.)
  * Returns offender messages; empty = OK. */
 export async function assertWorkflowFolderShape(
   dir: string,
@@ -524,6 +526,9 @@ if (import.meta.main) {
   // overlapping paths would double-test the same files.
   // Ignore live git-worktree dirs (engine creates them per run; they
   // hold frozen copies of older test files that no longer reflect HEAD).
+  // FR-E57 layout: `.flowai-workflow/<wf>/runs/<run-id>/worktree/`. Pre-FR-E57
+  // legacy path `.flowai-workflow/worktrees/` retained while a one-release
+  // resume fallback is in flight.
   if (await hasTestFiles(".")) {
     await run(
       "deno",
@@ -531,7 +536,7 @@ if (import.meta.main) {
         "test",
         "-A",
         "--no-check",
-        "--ignore=.flowai-workflow/worktrees,.claude/worktrees",
+        "--ignore=.flowai-workflow/worktrees,.flowai-workflow/*/runs,.claude/worktrees",
         ".",
       ],
       "Tests",

--- a/template_paths_test.ts
+++ b/template_paths_test.ts
@@ -52,7 +52,7 @@ Deno.test("buildTaskPaths — empty inputs yields empty input map", () => {
 
 Deno.test("interpolate — rendered {{node_dir}} contains no worktree prefix even when workDir is a worktree", () => {
   // Simulate the issue #196 v3 scenario.
-  const workDir = ".flowai-workflow/worktrees/20260425T222337";
+  const workDir = ".flowai-workflow/example/runs/20260425T222337/worktree";
   const paths = buildTaskPaths("20260425T222337", "verify");
   const ctx: TemplateContext = {
     ...paths,
@@ -75,7 +75,7 @@ Deno.test("interpolate — rendered {{node_dir}} contains no worktree prefix eve
 });
 
 Deno.test("interpolate — rendered {{input.X}} contains no worktree prefix", () => {
-  const workDir = ".flowai-workflow/worktrees/20260425T222337";
+  const workDir = ".flowai-workflow/example/runs/20260425T222337/worktree";
   const paths = buildTaskPaths("20260425T222337", "verify", [
     "specification",
   ]);
@@ -104,7 +104,7 @@ Deno.test("workPath(ctx.workDir, ctx.node_dir) reconstructs the FS path the engi
   // Engine internal code (cwd = main repo) must wrap ctx.node_dir with
   // workPath(ctx.workDir, …) to land on the actual file. This invariant
   // pins that contract.
-  const workDir = ".flowai-workflow/worktrees/20260425T222337";
+  const workDir = ".flowai-workflow/example/runs/20260425T222337/worktree";
   const paths = buildTaskPaths("20260425T222337", "verify");
   const ctx: TemplateContext = {
     ...paths,

--- a/worktree.ts
+++ b/worktree.ts
@@ -3,30 +3,58 @@
  * Git worktree lifecycle management for per-run isolation.
  * Each workflow run executes in its own worktree, eliminating destructive
  * `git reset --hard` and enabling future parallel runs.
+ *
+ * FR-E57 layout: a run's worktree lives at
+ * `<workflowDir>/runs/<run-id>/worktree/`, sibling to its `state.json` and
+ * per-node artifact directories under the same `runs/<run-id>/` parent.
+ * The pre-FR-E57 repo-global location `.flowai-workflow/worktrees/<run-id>`
+ * remains as a one-release legacy-resume fallback inside `worktreeExists`
+ * and `resolveExistingWorktreePath`; new worktrees are never created at it.
  */
 
-/** Base directory for worktrees (relative to original repo root). */
-const WORKTREE_BASE = ".flowai-workflow/worktrees";
+/**
+ * Pre-FR-E57 repo-global worktree base. Retained ONLY as a legacy-resume
+ * fallback inside `worktreeExists` / `resolveExistingWorktreePath` so that
+ * an in-flight run started on the old layout survives a binary upgrade.
+ * Slated for removal in a follow-up FR — never write here.
+ */
+const LEGACY_WORKTREE_BASE = ".flowai-workflow/worktrees";
 
-/** Get the worktree path for a given run ID (relative to repo root). */
-export function getWorktreePath(runId: string): string {
-  return `${WORKTREE_BASE}/${runId}`;
+/**
+ * Get the worktree path for a given run ID under `workflowDir`.
+ *
+ * Returns `<workflowDir>/runs/<runId>/worktree`. The `workflowDir` parameter
+ * mirrors the same value threaded into `getRunDir`/`getNodeDir`/
+ * `defaultLockPath` (FR-E54), so all per-run filesystem state lives under
+ * one `<workflowDir>/runs/<runId>/` umbrella.
+ */
+export function getWorktreePath(runId: string, workflowDir: string): string {
+  return `${workflowDir}/runs/${runId}/worktree`;
 }
 
 /**
  * Create a git worktree for a workflow run.
  * 1. Fetches latest from origin (fail fast on network error).
- * 2. Creates worktree at `.flowai-workflow/worktrees/<runId>` from `ref`.
+ * 2. Ensures `<workflowDir>/runs/<runId>/` parent exists (`git worktree add`
+ *    only mkdirs the leaf and fails if intermediate directories are
+ *    absent).
+ * 3. Creates worktree at `getWorktreePath(runId, workflowDir)` from `ref`,
+ *    detached.
  * Returns the relative worktree path.
  */
 export async function createWorktree(
   runId: string,
+  workflowDir: string,
   ref = "origin/main",
 ): Promise<string> {
   // Fetch latest
   await runGit(["fetch", "origin", "main"], "git fetch origin main failed");
 
-  const worktreePath = getWorktreePath(runId);
+  const worktreePath = getWorktreePath(runId, workflowDir);
+
+  // Ensure parent runs/<runId>/ dir exists; git worktree add creates only
+  // the leaf and fails when an intermediate dir is missing.
+  await Deno.mkdir(`${workflowDir}/runs/${runId}`, { recursive: true });
 
   // Create worktree (detached HEAD from ref)
   await runGit(
@@ -40,6 +68,12 @@ export async function createWorktree(
 /**
  * Remove a git worktree. Swallows NotFound errors (idempotent).
  * Uses --force to handle dirty worktrees (artifacts may have been written).
+ *
+ * After the primary remove, runs `git worktree prune` (idempotent,
+ * fail-silent) to clean up stale gitlinks under `.git/worktrees/<runId>/`.
+ * Without prune, a worktree directory removed out-of-band (manual rm,
+ * crashed cleanup) leaves behind a gitlink that blocks any future
+ * `git worktree add` at the same path.
  */
 export async function removeWorktree(worktreePath: string): Promise<void> {
   try {
@@ -48,26 +82,61 @@ export async function removeWorktree(worktreePath: string): Promise<void> {
       `git worktree remove failed for ${worktreePath}`,
     );
   } catch (err) {
-    // Swallow if worktree doesn't exist
+    // Swallow only the "worktree already gone" case. Anything else (e.g.,
+    // a dirty refusal we should never see because of --force) re-throws.
     if (
-      err instanceof Error &&
-      (err.message.includes("is not a working tree") ||
-        err.message.includes("No such file or directory"))
+      !(err instanceof Error &&
+        (err.message.includes("is not a working tree") ||
+          err.message.includes("No such file or directory")))
     ) {
-      return;
+      throw err;
     }
-    throw err;
+  }
+
+  // Tail prune. Idempotent; errors swallowed because git binary missing or
+  // a transient corruption shouldn't block teardown of the run state.
+  try {
+    await runGit(["worktree", "prune"], "git worktree prune failed");
+  } catch {
+    // intentional swallow
   }
 }
 
-/** Check if a worktree directory exists for the given run ID. */
-export function worktreeExists(runId: string): boolean {
-  try {
-    const info = Deno.statSync(getWorktreePath(runId));
-    return info.isDirectory;
-  } catch {
-    return false;
+/**
+ * Resolve an existing worktree for a (runId, workflowDir) pair.
+ *
+ * Probes the FR-E57 path first; falls back to the pre-FR-E57 repo-global
+ * layout when only the legacy directory is present. Returns `undefined` if
+ * neither path exists. The `legacy` flag lets callers (e.g., `Engine.run()`)
+ * surface a one-line warning that the old layout is still in use.
+ *
+ * The fallback exists only to let an in-flight resume cross the upgrade
+ * boundary; new worktrees are always created at the FR-E57 path. Removal
+ * scheduled for a follow-up FR.
+ */
+export function resolveExistingWorktreePath(
+  runId: string,
+  workflowDir: string,
+): { path: string; legacy: boolean } | undefined {
+  const fresh = getWorktreePath(runId, workflowDir);
+  const legacy = `${LEGACY_WORKTREE_BASE}/${runId}`;
+  for (const [p, isLegacy] of [[fresh, false], [legacy, true]] as const) {
+    try {
+      if (Deno.statSync(p).isDirectory) {
+        return { path: p, legacy: isLegacy };
+      }
+    } catch {
+      // not found, try next candidate
+    }
   }
+  return undefined;
+}
+
+/** Check whether a worktree directory exists for the given run ID under
+ * `workflowDir`. Honours the legacy-resume fallback — see
+ * {@link resolveExistingWorktreePath}. */
+export function worktreeExists(runId: string, workflowDir: string): boolean {
+  return resolveExistingWorktreePath(runId, workflowDir) !== undefined;
 }
 
 /**

--- a/worktree_test.ts
+++ b/worktree_test.ts
@@ -8,27 +8,124 @@ import {
   worktreeExists,
 } from "./worktree.ts";
 
-Deno.test("getWorktreePath — returns expected path", () => {
+Deno.test("getWorktreePath — returns <workflowDir>/runs/<runId>/worktree (FR-E57)", () => {
   assertEquals(
-    getWorktreePath("20260408T120000"),
-    ".flowai-workflow/worktrees/20260408T120000",
+    getWorktreePath("20260408T120000", ".flowai-workflow/example"),
+    ".flowai-workflow/example/runs/20260408T120000/worktree",
   );
 });
 
-Deno.test("getWorktreePath — includes label in path", () => {
+Deno.test("getWorktreePath — distinct workflow dirs produce disjoint paths (FR-E57)", () => {
+  const runId = "RUN";
+  const a = getWorktreePath(runId, ".flowai-workflow/wf-a");
+  const b = getWorktreePath(runId, ".flowai-workflow/wf-b");
+  assertEquals(a, ".flowai-workflow/wf-a/runs/RUN/worktree");
+  assertEquals(b, ".flowai-workflow/wf-b/runs/RUN/worktree");
+  assertEquals(a === b, false);
+});
+
+Deno.test("getWorktreePath — includes label in runId (FR-E57)", () => {
   assertEquals(
-    getWorktreePath("20260408T120000-my-feature"),
-    ".flowai-workflow/worktrees/20260408T120000-my-feature",
+    getWorktreePath("20260408T120000-my-feature", ".flowai-workflow/example"),
+    ".flowai-workflow/example/runs/20260408T120000-my-feature/worktree",
   );
 });
 
-Deno.test("worktreeExists — returns false for non-existent worktree", () => {
-  assertEquals(worktreeExists("nonexistent-run-id-abc123"), false);
+Deno.test("worktreeExists — returns false for non-existent worktree (FR-E57)", () => {
+  assertEquals(
+    worktreeExists("nonexistent-run-id-abc123", ".flowai-workflow/example"),
+    false,
+  );
+});
+
+Deno.test("worktreeExists — falls back to legacy path when only legacy exists (FR-E57)", async () => {
+  const tmp = await Deno.makeTempDir();
+  const origCwd = Deno.cwd();
+  try {
+    Deno.chdir(tmp);
+    // Set up only the legacy layout — no new-layout dir.
+    const runId = "legacy-run-id";
+    await Deno.mkdir(`.flowai-workflow/worktrees/${runId}`, {
+      recursive: true,
+    });
+    assertEquals(worktreeExists(runId, ".flowai-workflow/example"), true);
+  } finally {
+    Deno.chdir(origCwd);
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("worktreeExists — prefers new layout over legacy (FR-E57)", async () => {
+  const tmp = await Deno.makeTempDir();
+  const origCwd = Deno.cwd();
+  try {
+    Deno.chdir(tmp);
+    const runId = "preferred-run-id";
+    const workflowDir = ".flowai-workflow/example";
+    // Both paths exist; new path should win.
+    await Deno.mkdir(`${workflowDir}/runs/${runId}/worktree`, {
+      recursive: true,
+    });
+    await Deno.mkdir(`.flowai-workflow/worktrees/${runId}`, {
+      recursive: true,
+    });
+    assertEquals(worktreeExists(runId, workflowDir), true);
+  } finally {
+    Deno.chdir(origCwd);
+    await Deno.remove(tmp, { recursive: true });
+  }
 });
 
 Deno.test("removeWorktree — swallows error for non-existent worktree", async () => {
   // Should not throw for a path that doesn't exist
   await removeWorktree("/tmp/nonexistent-worktree-abc123");
+});
+
+Deno.test("removeWorktree — prunes stale gitlink after manual dir removal (FR-E57)", async () => {
+  const { tmpOrigin, tmpClone } = await setupOriginAndClone();
+  const origCwd = Deno.cwd();
+  try {
+    Deno.chdir(tmpClone);
+    const runId = "prune-test";
+    const workflowDir = ".flowai-workflow/example";
+    const worktreePath = await createWorktree(runId, workflowDir);
+
+    // git stores its bookkeeping under .git/worktrees/<basename>, where
+    // <basename> is derived from the worktree path's leaf and may be
+    // disambiguated on collision. Discover the actual entry rather than
+    // assuming a name.
+    const gitlinkRoot = `${tmpClone}/.git/worktrees`;
+    const beforeEntries: string[] = [];
+    for await (const e of Deno.readDir(gitlinkRoot)) {
+      if (e.isDirectory) beforeEntries.push(e.name);
+    }
+    assertEquals(
+      beforeEntries.length,
+      1,
+      `expected exactly one gitlink entry, got: ${beforeEntries.join(",")}`,
+    );
+
+    // Simulate a crashed cleanup: remove the worktree directory directly,
+    // leaving the gitlink dangling under .git/worktrees/.
+    await Deno.remove(worktreePath, { recursive: true });
+    assertEquals(
+      (await Deno.stat(`${gitlinkRoot}/${beforeEntries[0]}`)).isDirectory,
+      true,
+    );
+
+    // removeWorktree should swallow the "not a working tree" error AND
+    // call `git worktree prune` so the stale gitlink is gone afterwards.
+    await removeWorktree(worktreePath);
+
+    const gitlinkStillThere = await Deno.stat(
+      `${gitlinkRoot}/${beforeEntries[0]}`,
+    ).then(() => true, () => false);
+    assertEquals(gitlinkStillThere, false);
+  } finally {
+    Deno.chdir(origCwd);
+    await Deno.remove(tmpOrigin, { recursive: true });
+    await Deno.remove(tmpClone, { recursive: true });
+  }
 });
 
 Deno.test("createWorktree — fails on fetch error with bad remote", async () => {
@@ -84,7 +181,7 @@ Deno.test("createWorktree — fails on fetch error with bad remote", async () =>
     // createWorktree should fail because there's no 'origin' remote
     let thrown = false;
     try {
-      await createWorktree("test-run");
+      await createWorktree("test-run", ".flowai-workflow/example");
     } catch (e) {
       thrown = true;
       assertEquals(
@@ -99,50 +196,22 @@ Deno.test("createWorktree — fails on fetch error with bad remote", async () =>
   }
 });
 
-Deno.test("worktree lifecycle — create, exists, remove", async () => {
-  // Create a temporary repo with a local 'origin' to satisfy fetch
-  const tmpOrigin = await Deno.makeTempDir();
-  const tmpClone = await Deno.makeTempDir();
+Deno.test("worktree lifecycle — create, exists, remove (FR-E57 layout)", async () => {
+  const { tmpOrigin, tmpClone } = await setupOriginAndClone();
   const origCwd = Deno.cwd();
-
   try {
-    // Set up origin repo
-    await runGitCmd(["init", "--bare", "--initial-branch=main"], tmpOrigin);
-
-    // Clone it to get a working repo with origin
-    const clone = new Deno.Command("git", {
-      args: ["clone", tmpOrigin, tmpClone],
-      stdout: "null",
-      stderr: "null",
-    });
-    await clone.output();
-
-    // Configure and create initial commit on 'main'
-    await runGitCmd(["config", "user.email", "test@test.com"], tmpClone);
-    await runGitCmd(["config", "user.name", "Test"], tmpClone);
-    await runGitCmd(["checkout", "-b", "main"], tmpClone);
-    await Deno.writeTextFile(`${tmpClone}/README.md`, "test");
-    await runGitCmd(["add", "."], tmpClone);
-    await runGitCmd(["commit", "-m", "init"], tmpClone);
-    await runGitCmd(["push", "-u", "origin", "main"], tmpClone);
-
-    // Create worktrees directory
-    await Deno.mkdir(`${tmpClone}/.flowai-workflow/worktrees`, {
-      recursive: true,
-    });
-
-    // Change to clone dir
     Deno.chdir(tmpClone);
 
     const runId = "test-worktree-lifecycle";
+    const workflowDir = ".flowai-workflow/example";
 
     // Before creation: doesn't exist
-    assertEquals(worktreeExists(runId), false);
+    assertEquals(worktreeExists(runId, workflowDir), false);
 
     // Create worktree
-    const path = await createWorktree(runId);
-    assertEquals(path, `.flowai-workflow/worktrees/${runId}`);
-    assertEquals(worktreeExists(runId), true);
+    const path = await createWorktree(runId, workflowDir);
+    assertEquals(path, `${workflowDir}/runs/${runId}/worktree`);
+    assertEquals(worktreeExists(runId, workflowDir), true);
 
     // Verify worktree has files from origin/main
     const readme = await Deno.readTextFile(`${path}/README.md`);
@@ -150,7 +219,41 @@ Deno.test("worktree lifecycle — create, exists, remove", async () => {
 
     // Remove worktree
     await removeWorktree(path);
-    assertEquals(worktreeExists(runId), false);
+    assertEquals(worktreeExists(runId, workflowDir), false);
+  } finally {
+    Deno.chdir(origCwd);
+    await Deno.remove(tmpOrigin, { recursive: true });
+    await Deno.remove(tmpClone, { recursive: true });
+  }
+});
+
+Deno.test("createWorktree — distinct workflow dirs hold independent worktrees (FR-E57)", async () => {
+  const { tmpOrigin, tmpClone } = await setupOriginAndClone();
+  const origCwd = Deno.cwd();
+  try {
+    Deno.chdir(tmpClone);
+
+    const runId = "shared-run-id";
+    const wfA = ".flowai-workflow/wf-a";
+    const wfB = ".flowai-workflow/wf-b";
+
+    const pathA = await createWorktree(runId, wfA);
+    const pathB = await createWorktree(runId, wfB);
+
+    assertEquals(pathA, `${wfA}/runs/${runId}/worktree`);
+    assertEquals(pathB, `${wfB}/runs/${runId}/worktree`);
+    assertEquals(pathA === pathB, false);
+
+    // Both exist independently.
+    assertEquals(worktreeExists(runId, wfA), true);
+    assertEquals(worktreeExists(runId, wfB), true);
+
+    // Removing one leaves the other intact.
+    await removeWorktree(pathA);
+    assertEquals(worktreeExists(runId, wfA), false);
+    assertEquals(worktreeExists(runId, wfB), true);
+
+    await removeWorktree(pathB);
   } finally {
     Deno.chdir(origCwd);
     await Deno.remove(tmpOrigin, { recursive: true });
@@ -313,4 +416,29 @@ async function runGitCmd(args: string[], cwd: string): Promise<void> {
   if (!result.success) {
     throw new Error(`git ${args.join(" ")} failed in ${cwd}`);
   }
+}
+
+/** Set up a bare origin + working clone with one commit on `main`. */
+async function setupOriginAndClone(): Promise<
+  { tmpOrigin: string; tmpClone: string }
+> {
+  const tmpOrigin = await Deno.makeTempDir();
+  const tmpClone = await Deno.makeTempDir();
+  await runGitCmd(["init", "--bare", "--initial-branch=main"], tmpOrigin);
+
+  const clone = new Deno.Command("git", {
+    args: ["clone", tmpOrigin, tmpClone],
+    stdout: "null",
+    stderr: "null",
+  });
+  await clone.output();
+
+  await runGitCmd(["config", "user.email", "test@test.com"], tmpClone);
+  await runGitCmd(["config", "user.name", "Test"], tmpClone);
+  await runGitCmd(["checkout", "-b", "main"], tmpClone);
+  await Deno.writeTextFile(`${tmpClone}/README.md`, "test");
+  await runGitCmd(["add", "."], tmpClone);
+  await runGitCmd(["commit", "-m", "init"], tmpClone);
+  await runGitCmd(["push", "-u", "origin", "main"], tmpClone);
+  return { tmpOrigin, tmpClone };
 }


### PR DESCRIPTION
## Summary

- Co-locate the per-run git worktree with its `state.json` and per-node artifact directories under one `<workflowDir>/runs/<run-id>/` umbrella, superseding the pre-FR-E57 repo-global `.flowai-workflow/worktrees/<id>/` location.
- Closes a cross-workflow namespace gap that survived FR-E54: lock and runs were already per-workflow, but `WORKTREE_BASE` stayed repo-global, so two workflow folders running concurrently would have collided in one directory. New layout makes that impossible by construction.
- API breaking: `getWorktreePath`, `createWorktree`, `worktreeExists` now take `(runId, workflowDir, …)`. `Engine.run()` threads `this.workflowDir` into all three. Resume uses the new `resolveExistingWorktreePath`, which prefers the FR-E57 path and falls back once to the legacy repo-global location (with a one-line warning) so an in-flight run survives the upgrade. Legacy fallback is slated for removal in a follow-up FR — new worktrees are never created at it.
- Fail-fast guard in `Engine.run()`: worktree-mode + `workflowDir === "."` (the legacy bare-`workflow.yaml` case) is rejected with an error that names FR-S47/FR-E53. The new path would otherwise land at repo-root `./runs/<id>/worktree`, not covered by `.gitignore`. Users must pass the mandatory positional `<workflow>` argument or set `defaults.worktree_disabled: true`.
- `removeWorktree` calls `git worktree prune` after the primary remove (idempotent, fail-silent) so a worktree directory removed out-of-band no longer leaves a stale gitlink that blocks future `git worktree add` at the same path.

## Implements

- FR-E57: Per-Run Worktree Co-Location (NEW). 7/7 acceptance criteria `[x]` with file/line evidence in `documents/requirements-engine/04b-worktree-isolation.md`.

## Tests

- 8 new tests (798 passed | 0 failed total; baseline was 790):
  - `worktree_test.ts`: `getWorktreePath` returns new layout, distinct workflow dirs produce disjoint paths, `worktreeExists` prefers new layout, falls back to legacy when only legacy exists, `removeWorktree` prunes stale gitlink after manual dir removal, full lifecycle on new layout, distinct workflow dirs hold independent worktrees.
  - `engine_test.ts`: `Engine.run()` rejects worktree mode at root, accepts root `workflow.yaml` when `worktree_disabled: true`.
  - `e2e_worktree_isolation_test.ts`: distinct workflow dirs hold independent worktrees end-to-end.
- Existing 790 tests untouched semantically; 7 fixtures updated to reference the new layout.

## Docs

- SRS `§3.57 FR-E57` added with constraints, motivation, and 7 `[x]` acceptance criteria plus evidence.
- `AGENTS.md`, `README.md` tree diagrams, `CHANGELOG.md` (Unreleased BREAKING), `documents/design-engine/03-subsystems.md`, `documents/requirements-sdlc/04-artifacts-and-memory.md` aligned to the new layout.
- Misleading FR-E54 line claiming worktrees were "already per-workflow" replaced with a forward reference to FR-E57.
- `scripts/check.ts`: test-runner `--ignore` extended with `.flowai-workflow/*/runs` glob; `assertWorkflowFolderShape` JSDoc clarifies the new layout.

## Test plan

- [ ] `deno task check` green locally — verified: `798 passed | 0 failed`, fmt + lint + type + doc-lint + JSR `--dry-run` + workflow integrity all pass.
- [ ] Manual smoke: run the dogfood SDLC workflow and confirm worktree materializes at `.flowai-workflow/<wf>/runs/<run-id>/worktree/`, on success it is removed and `state.json` survives in the parent dir, on failure the rescue branch (FR-E51) still pins detached HEAD.
- [ ] Resume scenario: kill an in-flight run, restart with `--resume`, confirm legacy-fallback warning fires only when worktree was created on the old binary.
- [ ] Cross-workflow parallel sanity: kick off two runs in distinct `.flowai-workflow/<wf-a>/` and `<wf-b>/` simultaneously, confirm each sees its own worktree.

## Migration

End users: no action needed. Existing in-flight runs (worktree under `.flowai-workflow/worktrees/<id>/`) keep working through the legacy resume fallback for one release. Already-completed runs do not need migration — their worktrees were removed at success time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
