### PR TITLE
fix(sdlc): correct memory paths in github-inbox agent prompts

### DIFF
--- a/.flowai-workflow/github-inbox/agents/agent-architect.md
+++ b/.flowai-workflow/github-inbox/agents/agent-architect.md
@@ -41,7 +41,7 @@ All `gh issue comment` body strings MUST start with `**[Architect · plan]**`.
    directory (path from task message). Create directory if it doesn't exist.
 5. **Commit own changes:**
    ```
-   git add .flowai-workflow/memory/agent-architect.md .flowai-workflow/memory/agent-architect-history.md && git commit -m "sdlc(design): update Architect memory"
+   git add .flowai-workflow/github-inbox/memory/agent-architect.md .flowai-workflow/github-inbox/memory/agent-architect-history.md && git commit -m "sdlc(design): update Architect memory"
    ```
 
 ## Codebase Exploration
@@ -135,12 +135,12 @@ variant count, key trade-off, recommended direction.
 
 ## Reflection Memory
 
-- Memory: `.flowai-workflow/memory/agent-architect.md`
-- History: `.flowai-workflow/memory/agent-architect-history.md`
+- Memory: `.flowai-workflow/github-inbox/memory/agent-architect.md`
+- History: `.flowai-workflow/github-inbox/memory/agent-architect-history.md`
 
 ## Allowed File Modifications
 
 - `02-plan.md` in the node output directory.
-- `.flowai-workflow/memory/agent-architect.md`, `.flowai-workflow/memory/agent-architect-history.md`.
+- `.flowai-workflow/github-inbox/memory/agent-architect.md`, `.flowai-workflow/github-inbox/memory/agent-architect-history.md`.
 
 Do NOT touch any other files.

--- a/.flowai-workflow/github-inbox/agents/agent-developer.md
+++ b/.flowai-workflow/github-inbox/agents/agent-developer.md
@@ -53,7 +53,7 @@ All `gh issue comment` body strings MUST start with `**[Developer · implement]*
    Stage ONLY: (a) files from `03-decision.md` `tasks[].files`, (b) memory
    files, (c) run artifacts via `git add -f`.
    ```
-   git add -f <run-artifacts> && git add <task-files> .flowai-workflow/memory/agent-developer.md .flowai-workflow/memory/agent-developer-history.md && git commit -m "sdlc(impl): <summary>"
+   git add -f <run-artifacts> && git add <task-files> .flowai-workflow/github-inbox/memory/agent-developer.md .flowai-workflow/github-inbox/memory/agent-developer-history.md && git commit -m "sdlc(impl): <summary>"
    ```
    Commit body format:
    ```
@@ -130,14 +130,14 @@ like `.flowai-workflow/workflow/...`.
 
 ## Reflection Memory
 
-- Memory: `.flowai-workflow/memory/agent-developer.md`
-- History: `.flowai-workflow/memory/agent-developer-history.md`
+- Memory: `.flowai-workflow/github-inbox/memory/agent-developer.md`
+- History: `.flowai-workflow/github-inbox/memory/agent-developer-history.md`
 
 ## Allowed File Modifications
 
 - Files listed in `03-decision.md` YAML frontmatter `tasks[].files`.
 - Node output directory for artifacts.
-- `.flowai-workflow/memory/agent-developer.md`, `.flowai-workflow/memory/agent-developer-history.md`.
+- `.flowai-workflow/github-inbox/memory/agent-developer.md`, `.flowai-workflow/github-inbox/memory/agent-developer-history.md`.
 
 Explicitly forbidden (unless in `tasks[].files`):
 `.github/`, `.flowai-workflow/scripts/`, `.flowai-workflow/agents/`, `CLAUDE.md`.

--- a/.flowai-workflow/github-inbox/agents/agent-pm.md
+++ b/.flowai-workflow/github-inbox/agents/agent-pm.md
@@ -127,7 +127,7 @@ Draft ALL changes in your text response FIRST. Then:
 Stage and commit your memory files and SRS changes on local `main`. This commit
 will be carried into the feature branch when Tech Lead creates it.
 ```
-git add .flowai-workflow/memory/agent-pm.md .flowai-workflow/memory/agent-pm-history.md documents/requirements-*.md && git commit -m "sdlc(spec): update PM memory and SRS"
+git add .flowai-workflow/github-inbox/memory/agent-pm.md .flowai-workflow/github-inbox/memory/agent-pm-history.md documents/requirements-*.md && git commit -m "sdlc(spec): update PM memory and SRS"
 ```
 Only stage files you actually modified. If no SRS changes, omit the SRS glob.
 
@@ -201,13 +201,13 @@ Then MUST contain exactly these sections (Markdown H2 headings):
 
 ## Reflection Memory
 
-- Memory: `.flowai-workflow/memory/agent-pm.md`
-- History: `.flowai-workflow/memory/agent-pm-history.md`
+- Memory: `.flowai-workflow/github-inbox/memory/agent-pm.md`
+- History: `.flowai-workflow/github-inbox/memory/agent-pm-history.md`
 
 ## Allowed File Modifications
 
 - Target SRS file(s) based on scope detection.
 - `01-spec.md` in the node output directory.
-- `.flowai-workflow/memory/agent-pm.md`, `.flowai-workflow/memory/agent-pm-history.md`.
+- `.flowai-workflow/github-inbox/memory/agent-pm.md`, `.flowai-workflow/github-inbox/memory/agent-pm-history.md`.
 
 You MUST NOT modify SDS files, `AGENTS.md`, non-target SRS, or source code.

--- a/.flowai-workflow/github-inbox/agents/agent-qa.md
+++ b/.flowai-workflow/github-inbox/agents/agent-qa.md
@@ -55,7 +55,7 @@ All `gh pr review` and `gh issue comment` body strings MUST start with
 5. **Produce QA report:** Write verdict (PASS/FAIL) with detailed findings.
 6. **Commit own changes:**
    ```
-   git add .flowai-workflow/memory/agent-qa.md .flowai-workflow/memory/agent-qa-history.md && git commit -m "sdlc(verify): update QA memory" && git push origin HEAD
+   git add .flowai-workflow/github-inbox/memory/agent-qa.md .flowai-workflow/github-inbox/memory/agent-qa-history.md && git commit -m "sdlc(verify): update QA memory" && git push origin HEAD
    ```
 7. **Extend check suite (FR-S31):** When a recurring quality issue is detected
    across multiple runs, add a verification function to `scripts/check.ts`.
@@ -207,13 +207,13 @@ FAIL — 1/2 criteria passed, 1 blocking issue: test failure.
 
 ## Reflection Memory
 
-- Memory: `.flowai-workflow/memory/agent-qa.md`
-- History: `.flowai-workflow/memory/agent-qa-history.md`
+- Memory: `.flowai-workflow/github-inbox/memory/agent-qa.md`
+- History: `.flowai-workflow/github-inbox/memory/agent-qa-history.md`
 
 ## Allowed File Modifications
 
 - QA report at the path given in the task prompt.
-- `.flowai-workflow/memory/agent-qa.md`, `.flowai-workflow/memory/agent-qa-history.md`.
+- `.flowai-workflow/github-inbox/memory/agent-qa.md`, `.flowai-workflow/github-inbox/memory/agent-qa-history.md`.
 - `scripts/check.ts` (FR-S31, evidence-based only).
 
 Do NOT touch any other files.

--- a/.flowai-workflow/github-inbox/agents/agent-tech-lead-review.md
+++ b/.flowai-workflow/github-inbox/agents/agent-tech-lead-review.md
@@ -35,7 +35,7 @@ All `gh pr review` body strings MUST start with `**[Tech Lead Review · review]*
    `gh run list --branch "$(git branch --show-current)" --limit 5 --json status,conclusion`
 6. **Commit own changes:**
    ```
-   git add .flowai-workflow/memory/agent-tech-lead-review.md .flowai-workflow/memory/agent-tech-lead-review-history.md && git commit -m "sdlc(review): update Tech Lead Review memory" && git push origin HEAD
+   git add .flowai-workflow/github-inbox/memory/agent-tech-lead-review.md .flowai-workflow/github-inbox/memory/agent-tech-lead-review-history.md && git commit -m "sdlc(review): update Tech Lead Review memory" && git push origin HEAD
    ```
 7. **Verify clean working tree:** `git status --porcelain`. If non-empty →
    list uncommitted files in the report as a **blocking** finding. Do NOT merge.
@@ -95,12 +95,12 @@ All `gh pr review` body strings MUST start with `**[Tech Lead Review · review]*
 
 ## Reflection Memory
 
-- Memory: `.flowai-workflow/memory/agent-tech-lead-review.md`
-- History: `.flowai-workflow/memory/agent-tech-lead-review-history.md`
+- Memory: `.flowai-workflow/github-inbox/memory/agent-tech-lead-review.md`
+- History: `.flowai-workflow/github-inbox/memory/agent-tech-lead-review-history.md`
 
 ## Allowed File Modifications
 
 - `06-review.md` in the node output directory.
-- `.flowai-workflow/memory/agent-tech-lead-review.md`, `.flowai-workflow/memory/agent-tech-lead-review-history.md`.
+- `.flowai-workflow/github-inbox/memory/agent-tech-lead-review.md`, `.flowai-workflow/github-inbox/memory/agent-tech-lead-review-history.md`.
 
 Do NOT touch any other files.

--- a/.flowai-workflow/github-inbox/agents/agent-tech-lead.md
+++ b/.flowai-workflow/github-inbox/agents/agent-tech-lead.md
@@ -142,8 +142,8 @@ Fields:
 
 ## Reflection Memory
 
-- Memory: `.flowai-workflow/memory/agent-tech-lead.md`
-- History: `.flowai-workflow/memory/agent-tech-lead-history.md`
+- Memory: `.flowai-workflow/github-inbox/memory/agent-tech-lead.md`
+- History: `.flowai-workflow/github-inbox/memory/agent-tech-lead-history.md`
 
 ## Allowed File Modifications
 
@@ -151,6 +151,6 @@ Fields:
 - Target SDS file(s): `engine`→`design-engine.md`, `sdlc`→`design-sdlc.md`,
   `engine+sdlc`→both.
 - Git operations: branch creation, commits, push, draft PR.
-- `.flowai-workflow/memory/agent-tech-lead.md`, `.flowai-workflow/memory/agent-tech-lead-history.md`.
+- `.flowai-workflow/github-inbox/memory/agent-tech-lead.md`, `.flowai-workflow/github-inbox/memory/agent-tech-lead-history.md`.
 
 Do NOT modify source code, tests, SRS, or any other files.


### PR DESCRIPTION
## Summary
- All 6 agent prompts under `.flowai-workflow/github-inbox/agents/` referenced `.flowai-workflow/memory/agent-*.md` instead of `.flowai-workflow/github-inbox/memory/agent-*.md`.
- During run `20260524T015927`, the `decision` node (Tech Lead) wrote memory files to the wrong path; the guardrail flagged them as `scope_violation` and rolled the node back, failing the run.
- Discovered and patched by the supervisor while driving the workflow in loop mode.

## Test plan
- [ ] Resume the failed run: `flowai-workflow run .flowai-workflow/github-inbox --resume 20260524T015927`
- [ ] Confirm the `decision` node completes without `scope_violation` on memory files
- [ ] Verify written memory files land under `.flowai-workflow/github-inbox/memory/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)