### PR TITLE
fix(sync-plugins): pin git identity on clone so tag -a succeeds

### DIFF
--- a/scripts/sync-plugins-repo.ts
+++ b/scripts/sync-plugins-repo.ts
@@ -322,6 +322,23 @@ async function publishMode(
       throw new Error(`git clone ${targetRepo} failed: ${clone.stderr.trim()}`);
     }
 
+    // Pin a deterministic identity for `commit` AND `tag -a` in the
+    // freshly-cloned repo. Setting it via per-invocation `-c` covers
+    // `commit` but NOT `tag -a` (tag uses TAGGER_* env or git config;
+    // there is no `-c` overlay for the tagger). One-shot `git config`
+    // inside the clone is scoped to the clone — no side effect on the
+    // CI runner's other git work.
+    await mustGit(
+      deps.runGit,
+      ["config", "user.email", "github-actions[bot]@users.noreply.github.com"],
+      cloneDir,
+    );
+    await mustGit(
+      deps.runGit,
+      ["config", "user.name", "github-actions[bot]"],
+      cloneDir,
+    );
+
     // Find the engine SHA before any working-tree mutation so the
     // commit message records exactly what produced the payload.
     const shaOut = await deps.runGit(
@@ -370,20 +387,12 @@ async function publishMode(
       };
     }
 
-    // Commit + tag + push. Identity is set per-invocation so CI runners
-    // do not need a global git config.
+    // Commit + tag + push. Identity is pinned via `git config` above so
+    // both `commit` and `tag -a` pick up the same tagger.
     await mustGit(deps.runGit, ["add", "-A"], cloneDir);
     await mustGit(
       deps.runGit,
-      [
-        "-c",
-        "user.email=github-actions[bot]@users.noreply.github.com",
-        "-c",
-        "user.name=github-actions[bot]",
-        "commit",
-        "-m",
-        commitMessage(opts.version, engineSha),
-      ],
+      ["commit", "-m", commitMessage(opts.version, engineSha)],
       cloneDir,
     );
     const tag = `v${opts.version}`;


### PR DESCRIPTION
## Summary

First FR-E72 sync run (`workflow_dispatch v0.7.13` against `main`) failed at `git tag -a v0.7.13`:

> fatal: empty ident name (for `<runner@…>`) not allowed

Failed run: https://github.com/korchasa/flowai-workflow/actions/runs/26359028286

## Root cause

In `scripts/sync-plugins-repo.ts::publishMode`, I passed the committer identity via per-invocation `-c user.email=… -c user.name=…` flags to `git commit`. That works for `commit`, but **`git tag -a` does NOT honor `-c` overlays for the TAGGER fields** — `tag -a` reads identity exclusively from `git config` (or `GIT_COMMITTER_*` / `GIT_AUTHOR_*` env). With no global git config on the runner, `tag -a` fails immediately.

## Fix

Run `git config user.email/user.name` once inside the freshly-cloned target repo, right after `git clone`. Scope is local to the clone (no global side effect on the CI runner), and both `commit` and `tag -a` then resolve the same identity. The per-invocation `-c` flags on `commit` are removed since they're now redundant.

## Test plan

- [x] `deno task check` passes.
- [ ] After merge, re-trigger sync: `gh workflow run sync-plugins.yml --ref main --field version=0.7.13` — expect a `v0.7.13` commit + tag in `korchasa/flowai-workflow-plugins`.
- [ ] Manual smoke (post-sync): `/plugin marketplace add korchasa/flowai-workflow-plugins` + `/plugin install flowai-workflow@korchasa` in fresh Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)