### PR TITLE
ci: inline plugin sync after release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,23 @@ jobs:
             echo "released=false" >> $GITHUB_OUTPUT
           fi
 
+      # Inline sync of the plugin payload to korchasa/flowai-workflow-plugins.
+      # GITHUB_TOKEN-pushed tags don't trigger downstream workflows (recursion
+      # guard), so sync-plugins.yml's `push: tags: ['v*']` trigger never fires
+      # for CI-created releases — we publish directly in the same job instead.
+      # The workflow_dispatch trigger on sync-plugins.yml remains for manual
+      # re-runs. Step-output interpolation is routed via env: per the
+      # workflow-injection guidance (no `${{ steps.* }}` inside `run:`).
+      - name: Sync plugin payload to flowai-workflow-plugins
+        if: steps.create-release.outputs.released == 'true'
+        env:
+          PLUGINS_REPO_TOKEN: ${{ secrets.PLUGINS_REPO_TOKEN }}
+          RELEASE_VERSION: ${{ steps.create-release.outputs.version }}
+        run: |
+          deno run -A scripts/sync-plugins-repo.ts \
+            --mode publish \
+            --version "$RELEASE_VERSION"
+
   # Reads scripts/targets.json (single source of truth, also consumed by
   # scripts/compile.ts) and emits a GitHub Actions matrix. Keeping the list
   # in one file prevents drift between the local compile script and CI.


### PR DESCRIPTION
## Summary

- The release-tag push from `ci.yml` uses `GITHUB_TOKEN`, which by GitHub policy does not trigger downstream workflows (recursion guard). So `sync-plugins.yml`'s `push: tags: ['v*']` trigger never fires for CI-created releases — every release requires a manual `gh workflow run sync-plugins.yml` follow-up.
- Fix: invoke `scripts/sync-plugins-repo.ts --mode publish` as a final step of the release `check` job, gated by `steps.create-release.outputs.released == 'true'`. Existing `PLUGINS_REPO_TOKEN` is reused; `RELEASE_VERSION` is routed via `env:` per the workflow-injection guidance.
- `sync-plugins.yml` keeps its `push: tags: ['v*']` + `workflow_dispatch` triggers as fallbacks.

## Test plan

- [x] `deno task check` passes locally (lint + typecheck).
- [ ] After merge: next releasable PR (any `feat:` / `fix:` etc.) merged to main triggers ci.yml; release step runs; new step "Sync plugin payload to flowai-workflow-plugins" runs; downstream `korchasa/flowai-workflow-plugins` gets a matching `vX.Y.Z` commit + tag — without any manual `workflow_dispatch`.
- [ ] If the release step is skipped (no releasable commits), the sync step is also skipped (`if:` gate).
- [ ] If the inline sync fails, the whole CI run is red — drift between engine tag and downstream is surfaced immediately instead of silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)